### PR TITLE
Restrict capture to ARP packets

### DIFF
--- a/src/scanner/arp.rs
+++ b/src/scanner/arp.rs
@@ -77,6 +77,10 @@ pub async fn run_arp_scan(iface: &str, cidr: &str) -> Result<(), Box<dyn std::er
         .timeout(500)
         .open()?;
 
+    // Only capture ARP traffic
+    cap.filter("arp", true)
+        .map_err(|e| format!("Failed to set ARP filter: {}", e))?;
+
     let mut discovered: HashSet<(Ipv4Addr, MacAddr6)> = HashSet::new();
 
     for ip in network.iter().filter_map(|ip| match ip {


### PR DESCRIPTION
## Summary
- capture only ARP packets in `run_arp_scan`
- report errors when filter setup fails

## Testing
- `cargo build --quiet --offline` *(fails: no matching package named `ipnetwork` found)*
- `cargo build --quiet` *(fails to fetch crates index due to network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_685cd8ce6f84832cb2c57da4729dc225